### PR TITLE
fix: deploy webhook

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,4 +11,6 @@ jobs:
     steps:
       - name: Call VPS webhook
         run: |
-          curl -X POST ${WEBHOOK_URL}
+          curl -X POST "${WEBHOOK_URL}"
+        env:
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}


### PR DESCRIPTION
## Summary by Sourcery

Ensure the deploy workflow correctly loads and uses the WEBHOOK_URL secret by adding an env mapping and quoting it in the curl command

CI:
- Load WEBHOOK_URL from GitHub secrets in the deploy workflow
- Quote the WEBHOOK_URL argument in the curl command to ensure proper evaluation