### PR TITLE
feat: update configs to SSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,4 @@ RUN /app/static/css/tailwindcss -i /app/static/css/input.css -o /app/static/css/
 
 COPY . .
 
-RUN mkdir -p /var/www/certbot/.well-known/acme-challenge
-RUN chown -R www-data:www-data /var/www/certbot
-
-
 CMD ["gunicorn", "backend.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,23 @@ services:
       - web
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - static_volume:/app/productionfiles:ro
       - media_volume:/app/media:ro
       - ./certbot/www:/var/www/certbot
+      - ./certbot/conf:/etc/letsencrypt
 
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    env_file:
+      - .env
+    volumes:
+      - ./certbot/www:/var/www/certbot
+      - ./certbot/conf:/etc/letsencrypt
+    command: certonly --webroot -w /var/www/certbot --force-renewal --email ${CERTBOT_EMAIL} -d gomesystems.dev.br --agree-tos
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,8 @@ services:
     volumes:
       - ./certbot/www:/var/www/certbot
       - ./certbot/conf:/etc/letsencrypt
-    command: certonly --webroot -w /var/www/certbot --force-renewal --email ${CERTBOT_EMAIL} -d gomesystems.dev.br --agree-tos
+    command: certonly --webroot -w /var/www/certbot --email ${CERTBOT_EMAIL} -d gomesystems.dev.br --agree-tos
+    # To force renewal add --force-renewal flag to the command above
 
 volumes:
   postgres_data:

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,7 +38,7 @@ http {
         # Best practices for SSL
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;
-        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384';
         ssl_session_cache shared:SSL:10m;
 
         # SSL Stapling

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,13 +15,31 @@ http {
 
     server {
         listen 80;
-        server_name gomesystems.dev.br;
+        server_name gomesystems.dev.br www.gomesystems.dev.br;
 
-        # Redirect HTTP to HTTPS
+        # Redirect HTTP to HTTPS, but allow ACME challenge for certbot
         location /.well-known/acme-challenge/ {
-            root /var/www/certbot;
-            try_files $uri =404;
+            alias /var/www/certbot/.well-known/acme-challenge/;
+            try_files $uri $uri/ =404;
         }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name gomesystems.dev.br www.gomesystems.dev.br;
+
+        ssl_certificate /etc/letsencrypt/live/gomesystems.dev.br/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/gomesystems.dev.br/privkey.pem;
+
+        # Melhores práticas SSL
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers HIGH:!aNULL:!MD5;
+        ssl_session_cache shared:SSL:10m;
 
         # Serve static files
         location /static/ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,11 +35,21 @@ http {
         ssl_certificate /etc/letsencrypt/live/gomesystems.dev.br/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/gomesystems.dev.br/privkey.pem;
 
-        # Melhores práticas SSL
+        # Best practices for SSL
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;
         ssl_ciphers HIGH:!aNULL:!MD5;
         ssl_session_cache shared:SSL:10m;
+
+        # SSL Stapling
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        ssl_trusted_certificate /etc/letsencrypt/live/gomesystems.dev.br/chain.pem;
+        resolver 8.8.8.8 8.8.4.4 valid=300s;
+        resolver_timeout 5s;
+
+        # HSTS Header (1 year, include subdomains, preload)
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
         # Serve static files
         location /static/ {

--- a/scripts/update_ssl.sh
+++ b/scripts/update_ssl.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker-compose stop nginx
+docker-compose down
+certbot certonly --standalone -d gomesystems.dev.br -d www.gomesystems.dev.br
+docker-compose up -d


### PR DESCRIPTION
## Summary by Sourcery

Enable SSL/TLS support by configuring nginx with a secure HTTPS server block, automating certificate management with a new certbot service, updating docker-compose for SSL ports and volumes, and providing a script to obtain and renew certificates.

New Features:
- Add HTTPS server block with TLSv1.2/1.3 and HTTP/2 support in nginx
- Introduce a certbot service in docker-compose for automated certificate issuance
- Add update_ssl.sh script to generate and renew Let's Encrypt certificates

Enhancements:
- Redirect all HTTP traffic to HTTPS while allowing ACME challenge requests
- Add port mapping for 443 and mount SSL certificate volumes in docker-compose