### PR TITLE
fix: csrf into ssl

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -127,6 +127,10 @@ if ENV == 'prod':
         'HOST': config('POSTGRES_HOST'),
         'PORT': config('POSTGRES_PORT'),
     }
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    SECURE_SSL_REDIRECT = True
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
 
 DATABASES = {
     'default': DB,

--- a/certbot.yml
+++ b/certbot.yml
@@ -1,0 +1,9 @@
+version: "3.3"
+
+services:
+  certbot:
+    image: certbot/certbot
+    container_name: certbot
+    env_file:
+      - .env
+    command: certonly --webroot -w /var/www/certbot --force-renewal --email ${CERTBOT_EMAIL} -d gomesystems.dev.br --agree-tos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,18 +36,7 @@ services:
       - static_volume:/app/productionfiles:ro
       - media_volume:/app/media:ro
       - ./certbot/www:/var/www/certbot
-      - ./certbot/conf:/etc/letsencrypt
-
-  certbot:
-    image: certbot/certbot
-    container_name: certbot
-    env_file:
-      - .env
-    volumes:
-      - ./certbot/www:/var/www/certbot
-      - ./certbot/conf:/etc/letsencrypt
-    command: certonly --webroot -w /var/www/certbot --email ${CERTBOT_EMAIL} -d gomesystems.dev.br --agree-tos
-    # To force renewal add --force-renewal flag to the command above
+      - /etc/letsencrypt:/etc/letsencrypt
 
 volumes:
   postgres_data:

--- a/templates/partials/job_search_results.html
+++ b/templates/partials/job_search_results.html
@@ -15,8 +15,9 @@
       onclick="modal_job_details.showModal()">
       <div class="card-actions justify-end"></div>
       <time class="font-mono italic text-lg p-2 text-white rounded-t-lg bg-orange-300 time-badge">{{ job.time_range.start_date|date:'m/Y' }} - {{ job.time_range.end_date|date:'m/Y' }}</time>
+      
       <figure class="aspect-square">
-        <img class="bg-gray-500" src="{{ job.logo }}" alt="{{ job }} Logo" />
+        <img class="bg-gray-500 w-[200px] aspect-square ring-primary ring-offset-base-100 rounded ring-3" src="{{ job.logo }}" alt="{{ job }} Logo" />
       </figure>
 
       <div class="job-title">


### PR DESCRIPTION
## Summary by Sourcery

Enforce SSL and secure cookies in Django, refactor certificate handling into a dedicated compose file, and adjust job listing image styling.

Enhancements:
- Add SECURE_PROXY_SSL_HEADER, SECURE_SSL_REDIRECT, SESSION_COOKIE_SECURE, and CSRF_COOKIE_SECURE settings in Django
- Update job search result image classes to include width, aspect ratio, and decorative ring styling

Deployment:
- Remove embedded certbot service from docker-compose.yml and mount host letsencrypt directory into web container
- Introduce certbot.yml as a standalone compose file for certificate issuance and renewal